### PR TITLE
Add support for Redis clusters.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ class KeyvRedis extends EventEmitter {
 	constructor(uri, opts) {
 		super();
 
-		if (uri instanceof Redis) {
+		if (uri instanceof Redis || uri instanceof Redis.Cluster) {
 			this.redis = uri;
 		} else {
 			opts = Object.assign({}, typeof uri === 'string' ? { uri } : uri, opts);


### PR DESCRIPTION
From the [ioredis docs](https://github.com/luin/ioredis/blob/master/README.md#transaction-and-pipeline-in-cluster-mode):

>Almost all features that are supported by Redis are also supported by Redis.Cluster, e.g. custom commands, transaction and pipeline.

All of the features used here are supported by Redis.Cluster, so they should be accepted as well.